### PR TITLE
removing requirejs dependency from shim and sham

### DIFF
--- a/darwin
+++ b/darwin
@@ -1,0 +1,1 @@
+removing requirejs from es5-shim 


### PR DESCRIPTION
In order to avoid requireJS throwing an anonymous module definition exception , we needed to remove it from both shim and sham files.